### PR TITLE
remove unnecessary comments in rooms controller

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -156,11 +156,7 @@ class RoomsController < ApplicationController
   end
 
   def broadcast_update
-    # @room.broadcast_replace_to("room_#{@room.id}_resources/owner",
-    #                     target: "resources-list",
-    #                     partial: "shared/resources_list",
-    #                     locals: { user: "owner", room: @room })
-
+    # broadcast to the page that has turbo_stream tag of below channel name
     @room.broadcast_replace_to("room_#{@room.id}_resources/member",
                         target: "resources-list",
                         partial: "shared/resources_list",


### PR DESCRIPTION
- We used broadcast & turbo_stream to lively update each member's resource tab.
- Before broadcasting, we define each participants' roles to make sure only owner can edit the resources tab.